### PR TITLE
feat: Support Astro 5

### DIFF
--- a/.changeset/rare-stingrays-sin.md
+++ b/.changeset/rare-stingrays-sin.md
@@ -1,0 +1,5 @@
+---
+"astro-runtime-config": minor
+---
+
+feat: Support Astro 5

--- a/package/package.json
+++ b/package/package.json
@@ -34,10 +34,10 @@
   },
   "type": "module",
   "peerDependencies": {
-    "astro": "^4.14"
+    "astro": "^4.14 || ^5.0.0"
   },
   "dependencies": {
-    "astro-integration-kit": "^0.16.1"
+    "astro-integration-kit": "^0.18.0"
   },
   "devDependencies": {
     "tsup": "^8.3.0"

--- a/playground/package.json
+++ b/playground/package.json
@@ -11,8 +11,8 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^4.14",
-    "astro-integration-kit": "^0.16.1",
+    "astro": "^4.14 || ^5.0.0",
+    "astro-integration-kit": "^0.18.0",
     "astro-runtime-config": "workspace:*"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,11 +18,11 @@ importers:
   package:
     dependencies:
       astro:
-        specifier: ^4.14
+        specifier: ^4.14 || ^5.0.0
         version: 4.15.8(@types/node@20.16.5)(rollup@4.22.4)(typescript@5.6.2)
       astro-integration-kit:
-        specifier: ^0.16.1
-        version: 0.16.1(astro@4.15.8(@types/node@20.16.5)(rollup@4.22.4)(typescript@5.6.2))
+        specifier: ^0.18.0
+        version: 0.18.0(astro@4.15.8(@types/node@20.16.5)(rollup@4.22.4)(typescript@5.6.2))
     devDependencies:
       tsup:
         specifier: ^8.3.0
@@ -31,11 +31,11 @@ importers:
   playground:
     dependencies:
       astro:
-        specifier: ^4.14
+        specifier: ^4.14 || ^5.0.0
         version: 4.15.8(@types/node@20.16.5)(rollup@4.22.4)(typescript@5.6.2)
       astro-integration-kit:
-        specifier: ^0.16.1
-        version: 0.16.1(astro@4.15.8(@types/node@20.16.5)(rollup@4.22.4)(typescript@5.6.2))
+        specifier: ^0.18.0
+        version: 0.18.0(astro@4.15.8(@types/node@20.16.5)(rollup@4.22.4)(typescript@5.6.2))
       astro-runtime-config:
         specifier: workspace:*
         version: link:../package
@@ -999,10 +999,10 @@ packages:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
 
-  astro-integration-kit@0.16.1:
-    resolution: {integrity: sha512-N/iam0PAFrRT9azYZqscP1HowQhC77Dwlp912P0/72k+kwUVgO3m73F26XXukHYoZBsrHgrUrfsWBxuCH3kEUg==}
+  astro-integration-kit@0.18.0:
+    resolution: {integrity: sha512-Z0QW5IQjosuKQDEGYYkvUX6EhEtrmE4/oViqWz23QveV8U7AuyFsTdg00WRNPevWZl/5a4lLUeDpv4bCRynRRg==}
     peerDependencies:
-      astro: ^4.12.0
+      astro: ^4.12.0 || ^5.0.0
 
   astro@4.15.8:
     resolution: {integrity: sha512-pdXjtRF6O1xChiPAUF32R7oVRTW7AK1/Oy/JqPNhLfbelO0l6C7cLdSEuSLektwOEnMhOVXqccetjBs7HPaoxA==}
@@ -3564,7 +3564,7 @@ snapshots:
     dependencies:
       tslib: 2.7.0
 
-  astro-integration-kit@0.16.1(astro@4.15.8(@types/node@20.16.5)(rollup@4.22.4)(typescript@5.6.2)):
+  astro-integration-kit@0.18.0(astro@4.15.8(@types/node@20.16.5)(rollup@4.22.4)(typescript@5.6.2)):
     dependencies:
       astro: 4.15.8(@types/node@20.16.5)(rollup@4.22.4)(typescript@5.6.2)
       pathe: 1.1.2


### PR DESCRIPTION
This PR fixes the following warning when upgrading to Astro 5:

```
> pnpm update
Progress: resolved 769, reused 643, downloaded 0, added 0, done
 WARN  Issues with peer dependencies found
.
└─┬ astro-runtime-config 2.0.0
  ├── ✕ unmet peer astro@^4.14: found 5.0.9
  └─┬ astro-integration-kit 0.16.1
    └── ✕ unmet peer astro@^4.12.0: found 5.0.9

Done in 7s
```